### PR TITLE
Documentation Ruleset no error on missing Request Body description

### DIFF
--- a/documentation.js
+++ b/documentation.js
@@ -57,7 +57,7 @@ export default {
         '$.server',
         '$.externalDocs',
         '$.paths.*.*.parameters.*',
-        '$.paths.*.*.requestBody',
+        '$.paths.*.*.requestBody.content.*.schema.properties.*',
         '$.paths.*.*.responses.*',
         '$.paths.*.*.examples.*',
         '$.paths.*.*.responses.links.*',


### PR DESCRIPTION
Documentation ruleset does not need to error if the description for the requestBody is missing. 

However, the rule should error if descriptions for items in the request body are lacking description.