### PR TITLE
add exceptions array to multi-version

### DIFF
--- a/functions/multiVersion.js
+++ b/functions/multiVersion.js
@@ -21,6 +21,32 @@
 import { isObject } from '../util/funcUtils.js';
 
 /**
+ * Items that cause false positives when checking for versions.
+ */
+const VERSION_EXCEPTIONS = [
+  /* <sd-wan> */
+  "dhcpv6",
+  "dataipv6prefix",
+  "ikev1",
+  "v4fib",
+  "v6fib",
+  "v3interface",
+  "ipv6",
+  "ipv4",
+  "ipv6prefix",
+  "dhcpv4",
+  "v3interface",
+  "v3neighbor",
+  "deviceaccesspolicyv6",
+  "ipv6Stats",
+  /* </sd-wan> */
+  /* <meraki> */
+  "dhcp/v4",
+  "dhcp/v6"
+  /* </meraki> */ 
+];
+
+/**
  * Checks if there is only one version in server urls and paths.
  * @param {string} targetVal The string to lint
  * @param {object} opts checks to do
@@ -157,8 +183,17 @@ function* getAllServerURLs(doc) {
 }
 
 function getVersion(str) {
+
+  // Replace exceptions with placeholders and then check for version
+  for (const exception of VERSION_EXCEPTIONS) {
+    if (str.includes(exception)) {
+      str = str.replace(exception, '');
+    }
+  }
+
+  const versionRegex = /v\d+[^/]*/;
   let version = '';
-  const parts = str.match(/v\d+[^/]*/);
+  const parts = str.match(versionRegex);
 
   if (parts) {
     version =  parts[0];


### PR DESCRIPTION
For the multi-version regex, add an exceptions array to remove from paths before checking against versions