### PR TITLE
Updates to the multi-version fonction and 'contract.js' ruleset

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -37,7 +37,7 @@ export default {
     'oas3-schema': 'error',
     'oas2-schema': 'error',
     'oas3-missing-schema-definition': {
-      'description': 'There is no schema attribute for a component.',
+      'description': 'a schema must describe the structure of responses (except 204s) and request bodies if any',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas3],
@@ -53,7 +53,7 @@ export default {
       },
     },
     'oas2-missing-schema-definition': {
-      'description': 'There is no schema attribute for a component.',
+      'description': 'a schema must describe the structure of responses (except 204s) and request bodies if any',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
@@ -69,7 +69,7 @@ export default {
       },
     },
     'general-schema-definition': {
-      'description': 'Some of the defined schema use object as a final field when describing their object structure',
+      'description': 'schemas must be fully defined and should not use \'object\' as a final type',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': [
@@ -87,7 +87,7 @@ export default {
       ],
     },
     'oas3-missing-returned-representation': {
-      'description': '2XX (except 204) responses must have a response schema defined',
+      'description': 'a response schema must be defined for 2xx responses (except 204)',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas3],
@@ -100,7 +100,7 @@ export default {
       },
     },
     'oas2-missing-returned-representation': {
-      'description': '2XX (except 204) responses must have a response schema defined.',
+      'description': 'a response schema must be defined for 2xx responses (except 204)',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
@@ -113,7 +113,7 @@ export default {
       },
     },
     'success-status-code': {
-      'description': 'For every operation in the OAS document, there should be at least one success status code defined.  A successful status code is in the 1xx, 2xx or 3xx range series, and generally a 200, 201 or 204.',
+      'description': 'responses must include a success status code in the 1xx, 2xx or 3xx range (generally 200, 201 or 204)',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': '$.paths.*.*.responses',
@@ -125,7 +125,7 @@ export default {
       },
     },
     'error-status-code': {
-      'description': 'There should be at least one error status code either 4xx or 5xx.',
+      'description': 'responses should include at least one error status code (4xx or 5xx)',
       'message': '{{description}}; {{error}}',
       'severity': 'warn',
       'given': '$.paths.*.*.responses',
@@ -141,7 +141,7 @@ export default {
       },
     },
     'oas2-meta-info': {
-      'description': 'Some meta fields must be present.',
+      'description': 'some meta fields are missing',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
@@ -162,8 +162,8 @@ export default {
         },
       },
     },
-    'multi-versions-server-url-missing-version': {
-      'description': 'No version is specified in the server object of the OpenAPI Document. Best practices recommend specifying the version in the server object only once',
+    'server-url-missing-version': {
+      'description': 'the API version should be specified in the \'server.url\' field',
       'message': '{{description}}; {{error}}',
       'severity': 'warn',
       'given': [
@@ -172,12 +172,12 @@ export default {
       'then': {
         'function': multiVersion,
         'functionOptions': {
-          'check': 'server-url-missing',
+          'check': 'server-url-missing'
         },
       },
     },
     'multi-versions': {
-      'description': 'should only contain a single API version at a time.',
+      'description': 'all paths should reference a single API version',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': [
@@ -185,10 +185,13 @@ export default {
       ],
       'then': {
         'function': multiVersion,
+        'functionOptions': {
+          'exceptions' : [ "networks/{networkId}/switch/dhcp/v4" ]
+        },
       },
     },
     'operationId-required-and-unique': {
-      'description': 'operationId must be required and uniq',
+      'description': 'an \'operationId\' field must be present for every operation and must be unique',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': [

--- a/contract.js
+++ b/contract.js
@@ -37,7 +37,7 @@ export default {
     'oas3-schema': 'error',
     'oas2-schema': 'error',
     'oas3-missing-schema-definition': {
-      'description': 'a schema must describe the structure of responses (except 204s) and request bodies if any',
+      'description': 'There is no schema attribute for a component.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas3],
@@ -53,7 +53,7 @@ export default {
       },
     },
     'oas2-missing-schema-definition': {
-      'description': 'a schema must describe the structure of responses (except 204s) and request bodies if any',
+      'description': 'There is no schema attribute for a component.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
@@ -69,7 +69,7 @@ export default {
       },
     },
     'general-schema-definition': {
-      'description': 'schemas must be fully defined and should not use \'object\' as a final type',
+      'description': 'Some of the defined schema use object as a final field when describing their object structure',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': [
@@ -87,7 +87,7 @@ export default {
       ],
     },
     'oas3-missing-returned-representation': {
-      'description': 'a response schema must be defined for 2xx responses (except 204)',
+      'description': '2XX (except 204) responses must have a response schema defined',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas3],
@@ -100,7 +100,7 @@ export default {
       },
     },
     'oas2-missing-returned-representation': {
-      'description': 'a response schema must be defined for 2xx responses (except 204)',
+      'description': '2XX (except 204) responses must have a response schema defined.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
@@ -113,7 +113,7 @@ export default {
       },
     },
     'success-status-code': {
-      'description': 'responses must include a success status code in the 1xx, 2xx or 3xx range (generally 200, 201 or 204)',
+      'description': 'For every operation in the OAS document, there should be at least one success status code defined. A successful status code is in the 1xx, 2xx or 3xx range series, and generally a 200, 201 or 204.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': '$.paths.*.*.responses',
@@ -141,7 +141,7 @@ export default {
       },
     },
     'oas2-meta-info': {
-      'description': 'some meta fields are missing',
+      'description': 'Some meta fields must be present.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
@@ -162,8 +162,8 @@ export default {
         },
       },
     },
-    'server-url-missing-version': {
-      'description': 'the API version should be specified in the \'server.url\' field',
+    'multi-versions-server-url-missing-version': {
+      'description': 'path should not have version while server object has one',
       'message': '{{description}}; {{error}}',
       'severity': 'warn',
       'given': [
@@ -177,7 +177,7 @@ export default {
       },
     },
     'multi-versions': {
-      'description': 'all paths should reference a single API version',
+      'description': 'should only contain a single API version at a time.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': [
@@ -191,7 +191,7 @@ export default {
       },
     },
     'operationId-required-and-unique': {
-      'description': 'an \'operationId\' field must be present for every operation and must be unique',
+      'description': 'operationId must be required and uniq',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': [

--- a/functions/multiVersion.js
+++ b/functions/multiVersion.js
@@ -97,7 +97,7 @@ export default function (targetVal, opts) {
     if (pathFirstVersion === '') {
       if (serverFirstVersion !== '') {
         results.push({
-          message: `the path should not include a version number when the \'servers.url\' attribute already does: \'servers.url\' version detected is /${serverFirstVersion}`,
+          message: `path should not have version while server object has one.`,
           path: ['paths', path],
         });
       }
@@ -107,7 +107,7 @@ export default function (targetVal, opts) {
 
     if (pathFirstVersion !== version) {
       results.push({
-        message: `more than one version has been detected across paths: /${pathFirstVersion} and /${version}`,
+        message: `multi versions in paths.`,
         path: ['paths', path],
       });
     }

--- a/functions/multiVersion.js
+++ b/functions/multiVersion.js
@@ -19,32 +19,7 @@
 'use strict';
 
 import { isObject } from '../util/funcUtils.js';
-
-/**
- * Items that cause false positives when checking for versions.
- */
-const VERSION_EXCEPTIONS = [
-  /* <sd-wan> */
-  "dhcpv6",
-  "dataipv6prefix",
-  "ikev1",
-  "v4fib",
-  "v6fib",
-  "v3interface",
-  "ipv6",
-  "ipv4",
-  "ipv6prefix",
-  "dhcpv4",
-  "v3interface",
-  "v3neighbor",
-  "deviceaccesspolicyv6",
-  "ipv6Stats",
-  /* </sd-wan> */
-  /* <meraki> */
-  "dhcp/v4",
-  "dhcp/v6"
-  /* </meraki> */ 
-];
+import getVersion from '../util/getVersion.js';
 
 /**
  * Checks if there is only one version in server urls and paths.
@@ -180,24 +155,4 @@ function* getAllServerURLs(doc) {
     item.url = url;
     yield item;
   }
-}
-
-function getVersion(str) {
-
-  // Replace exceptions with placeholders and then check for version
-  for (const exception of VERSION_EXCEPTIONS) {
-    if (str.includes(exception)) {
-      str = str.replace(exception, '');
-    }
-  }
-
-  const versionRegex = /v\d+[^/]*/;
-  let version = '';
-  const parts = str.match(versionRegex);
-
-  if (parts) {
-    version =  parts[0];
-  }
-
-  return version;
 }

--- a/functions/multiVersion.js
+++ b/functions/multiVersion.js
@@ -21,6 +21,32 @@
 import { isObject } from '../util/funcUtils.js';
 
 /**
+ * Items that cause false positives when checking for versions.
+ */
+const VERSION_EXCEPTIONS = [
+  /* <sd-wan> */
+  "dhcpv6",
+  "dataipv6prefix",
+  "ikev1",
+  "v4fib",
+  "v6fib",
+  "v3interface",
+  "ipv6",
+  "ipv4",
+  "ipv6prefix",
+  "dhcpv4",
+  "v3interface",
+  "v3neighbor",
+  "deviceaccesspolicyv6",
+  "ipv6Stats",
+  /* </sd-wan> */
+  /* <meraki> */
+  "dhcp/v4",
+  "dhcp/v6"
+  /* </meraki> */ 
+];
+
+/**
  * Checks if there is only one version in server urls and paths.
  * @param {string} targetVal The string to lint
  * @param {object} opts checks to do
@@ -157,8 +183,17 @@ function* getAllServerURLs(doc) {
 }
 
 function getVersion(str) {
+
+  // Replace exceptions with placeholders and then check for version
+  for (const exception of VERSION_EXCEPTIONS) {
+    if (str.includes(exception)) {
+      str = str.replace(exception, '');
+    }
+  }
+
+  const versionRegex = /v\d+[^/]*/;
   let version = '';
-  const parts = str.match(/v\d+[^/]*/);
+  const parts = str.match(versionRegex);
 
   if (parts) {
     version =  parts[0];

--- a/functions/multiVersion.js
+++ b/functions/multiVersion.js
@@ -21,6 +21,13 @@
 import { isObject } from '../util/funcUtils.js';
 import getVersion from '../util/getVersion.js';
 
+// Corner cases of API paths that are indeed versions on the url BUT should not be flagged by the rule
+const PATH_EXCEPTIONS = [ 
+  // Meraki: /networks/{networkId}/switch/dhcp/v4/servers/seen
+  "dhcp/v1" ,
+];
+
+
 /**
  * Checks if there is only one version in server urls and paths.
  * @param {string} targetVal The string to lint
@@ -79,7 +86,7 @@ export default function (targetVal, opts) {
   let pathFirstVersion = '';
 
   for (const { path } of getAllPaths(paths)) {
-    const version = getVersion(path);
+    const version = getVersion(path, PATH_EXCEPTIONS);
 
     if (version === '') {
       continue;

--- a/test/CHANGELOG
+++ b/test/CHANGELOG
@@ -1,0 +1,11 @@
+# Changelog
+
+## October 24th, 2024
+
+The 'multi-version' rule received several updates:
+- it does not consider any more 'v*' patterns in path such as 'ipv6' as version number.
+- the rule also support expections for paths such as '/api/dhcp/v4' where v4 should not be considered as a version number per the API design.
+
+The 'Contract' ruleset has been updated to include an exception for path "networks/{networkId}/switch/dhcp/v4" of the Meraki API.
+
+

--- a/util/getVersion.js
+++ b/util/getVersion.js
@@ -1,0 +1,18 @@
+
+export default function getVersion(str) {
+
+    //const versionRegex = /v\d+[^/]*/;
+    // const versionRegex = /\b\/?v\d+(\.\d+)*\//;
+    const versionRegex = /\b\/?v\d+(\.\d+)*\/?(\b|$)/;
+    let version = '';
+    const parts = str.match(versionRegex);
+
+    if (parts) {
+        version =  parts[0];
+        version = version.charAt(0) === '/' ? version.slice(1) : version;
+        version = version.charAt(version.length - 1) === '/' ? version.slice(0, -1) : version;
+    }
+
+    return version;
+}
+  

--- a/util/getVersion.js
+++ b/util/getVersion.js
@@ -1,8 +1,6 @@
 
 export default function getVersion(str) {
 
-    //const versionRegex = /v\d+[^/]*/;
-    // const versionRegex = /\b\/?v\d+(\.\d+)*\//;
     const versionRegex = /\b\/?v\d+(\.\d+)*\/?(\b|$)/;
     let version = '';
     const parts = str.match(versionRegex);

--- a/util/getVersion.js
+++ b/util/getVersion.js
@@ -10,16 +10,17 @@ export default function getVersion(str, exceptionList) {
         }
     }
 
-    // The version regex is pretty complex to address most use cases at Cisco, check this asana issue for context:
-    // The regexp requires to remove leading or trailing '/' if any.
-    const versionRegex = /\b\/?v\d+(\.\d+)*\/?(\b|$)/;
+    // The version regex is pretty complex to address all use cases at Cisco
+    // Please check this Asana issue for full context and explorations: https://app.asana.com/0/1206872740398257/1206657704786474
+    //const versionRegex = /\b\/?v\d+(\.\d+)*\/?(\b|$)/;  // does not fully work, captures v6 as a version number for path: "/device/cedgecflowd/app-fwd-cflowd-v6-flows"
+    const versionRegex = /(?<![-\w])\/?v\d+(\.\d+)*\/?(\b|$)/;    // does NOT capture v6 as a version number for path: "/device/cedgecflowd/app-fwd-cflowd-v6-flows"
 
     let version = '';
     const parts = str.match(versionRegex);
     if (parts) {
         version = parts[0];
 
-        // Remove leading or trailing '/' 
+        // The latest regexp captures /v1 in some cases, let's remove leading or trailing '/' if any
         version = version.charAt(0) === '/' ? version.slice(1) : version;
         version = version.charAt(version.length - 1) === '/' ? version.slice(0, -1) : version;
     }

--- a/util/getVersion.js
+++ b/util/getVersion.js
@@ -1,16 +1,28 @@
 
-export default function getVersion(str) {
+export default function getVersion(str, exceptionList) {
 
+    // Exclude paths fragments that are considered exceptions
+    if (exceptionList) {
+        for (const exception of exceptionList) {
+            if (str.includes(exception)) {
+                str = str.replace(exception, 'EXCEPTION');
+            }
+        }
+    }
+
+    // The version regex is pretty complex to address most use cases at Cisco, check this asana issue for context:
+    // The regexp requires to remove leading or trailing '/' if any.
     const versionRegex = /\b\/?v\d+(\.\d+)*\/?(\b|$)/;
+
     let version = '';
     const parts = str.match(versionRegex);
-
     if (parts) {
-        version =  parts[0];
+        version = parts[0];
+
+        // Remove leading or trailing '/' 
         version = version.charAt(0) === '/' ? version.slice(1) : version;
         version = version.charAt(version.length - 1) === '/' ? version.slice(0, -1) : version;
     }
 
     return version;
 }
-  

--- a/util/getVersion.spec.js
+++ b/util/getVersion.spec.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import getVersion from './getVersion.js';
+import { describe, expect, jest, test } from '@jest/globals';
+
+describe('getVersion', () => {
+    const serverUrls = [
+        {
+          url: 'http://api.example1.com/v1.2/',
+          version: 'v1.2'
+        },
+        {
+          url: 'http://api.example1.com/v1',
+          version: 'v1'
+        }
+      ]
+      
+      const paths = [
+        {
+          path: 'v2/my/bad/path',
+          version: 'v2'
+        },
+        {
+          path: '/v2.1.0/my/path',
+          version: 'v2.1.0'
+        },
+        {
+          path: '/api/v1/cloudonramp/saas',
+          version: 'v1'
+        },
+        {
+          path: '/api/v1/config-group',
+          version: 'v1'
+        },
+        {
+          path: '/api/v1/config-group/{configGroupId}',
+          version: 'v1'
+        },
+        {
+          path: '/api/v2/data/device/statistics/interfacestatistics/fields',
+          version: 'v2'
+        },
+        {
+          path: '/api/device/dhcpv6/intesface',
+          version: ''
+        },
+        {
+          path: '/api/v2.1.0/device/dhcpv6/intesface',
+          version: 'v2.1.0'
+        },
+        {
+          path: '/api/device/interface/ipv6Stats',
+          version: ''
+        },
+        {
+          path: '/api/device/ip/v4fib',
+          version: ''
+        },
+        {
+          path: '/api/device/ip/v6fib',
+          version: ''
+        },
+        {
+          path: '/api/device/ipsec/ikev1',
+          version: ''
+        },
+        {
+          path: '/api/device/ipsec/ikev2',
+          version: ''
+        },
+        {
+          path: '/api/device/ipv6/nd6',
+          version: ''
+        },
+        {
+          path: '/api/device/ndv6',
+          version: ''
+        },
+        {
+          path: '/api/device/omp/routes/advertised/ompIpv6',
+          version: ''
+        },
+        {
+          path: '/api/device/omp/routes/received/ompIpv6',
+          version: ''
+        },
+        {
+          path: '/api/device/ospf/v3interface',
+          version: ''
+        },
+        {
+          path: '/api/device/ospf/v3neighbor',
+          version: ''
+        },
+        {
+          path: '/api/device/policy/ipv6/accesslistassociations',
+          version: ''
+        },
+        {
+          path: '/api/device/policy/ipv6/accesslistcounters',
+          version: ''
+        },
+        {
+          path: '/api/device/policy/ipv6/accesslistnames',
+          version: ''
+        },
+        {
+          path: '/api/device/policy/ipv6/accesslistpolicers',
+          version: ''
+        },
+        {
+          path: '/api/device/roleBasedIpv6Counters',
+          version: ''
+        },
+        {
+          path: '/api/device/roleBasedIpv6Permissions',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/aclv6',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/aclv6/bulk',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/aclv6/multiple/{id}',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/aclv6/{id}',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/deviceaccesspolicyv6',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/deviceaccesspolicyv6/bulk',
+          version: ''
+        },
+        {
+          path: '/api/template/policy/definition/deviceaccesspolicyv6/multiple/{id}',
+          version: ''
+        }
+      ]
+      
+
+      test('should return the version from the server urls', () => {
+        serverUrls.forEach(serverUrl => {
+            const version = getVersion(serverUrl.url);
+            expect(version).toEqual(serverUrl.version);
+            });
+      });
+
+      test('should return the version from the paths', () => {
+        paths.forEach(path => {
+            const version = getVersion(path.path);
+            expect(version).toEqual(path.version);
+        });
+    });  
+});
+


### PR DESCRIPTION
- improved regexp to support corner cases, see https://app.asana.com/0/1206872740398257/1206657704786474/f
- added an exception list for paths that include version numbers by design such as Meraki 'dhcp/v4'
- simplified name of rule 'multi-versions-server-url-missing-version]' to 'server-url-missing-version'
- simplifications, clarifications and more consistent spectral messages 
