### PR TITLE
Added custom resolver to ignore external HTTP/HTTPS references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@cisco-developer/api-insights-openapi-rulesets",
-  "version": "v0.0.0",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cisco-developer/api-insights-openapi-rulesets",
-      "version": "v0.0.0",
+      "version": "0.1.23",
       "license": "Apache2",
       "dependencies": {
         "@jest/globals": "^29.0.3",
+        "@stoplight/json-ref-resolver": "^3.1.6",
         "@stoplight/spectral-cli": "6.9.0",
         "@stoplight/spectral-core": "1.18.3",
         "@stoplight/spectral-formats": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-developer/api-insights-openapi-rulesets",
-  "version": "v0.0.0",
+  "version": "0.1.23",
   "description": "API Insights Spectral rulesets",
   "type": "module",
   "scripts": {
@@ -24,6 +24,7 @@
   "author": "DevRel",
   "dependencies": {
     "@jest/globals": "^29.0.3",
+    "@stoplight/json-ref-resolver": "^3.1.6",
     "@stoplight/spectral-cli": "6.9.0",
     "@stoplight/spectral-core": "1.18.3",
     "@stoplight/spectral-formats": "1.6.0",

--- a/resolvers/ignore-external-refs.cjs
+++ b/resolvers/ignore-external-refs.cjs
@@ -1,0 +1,61 @@
+// Copyright 2024 Cisco Systems, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Custom resolver for Spectral that behaves like the default resolver
+ * but does not resolve external dependencies (e.g., URLs pointing to HTTP/HTTPS links).
+ * This prevents network timeouts and 504 errors when processing OpenAPI specs
+ * that contain external $ref attributes in examples (like SCIM specifications).
+ * 
+ * External references are returned as-is without modification, while internal
+ * references (starting with #) are processed normally by the default resolver.
+ */
+
+const { Resolver } = require("@stoplight/json-ref-resolver");
+const { URL } = require('url');
+
+class CustomResolver extends Resolver {
+  constructor() {
+    super();
+  }
+
+  async resolve(ref, baseUri, options) {
+    try {
+      const parsedUrl = new URL(ref);
+
+      if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+        if (process.env.DEBUG_SPECTRAL_RESOLVER) {
+          console.log(`[CUSTOM-RESOLVER] Ignoring external $ref: '${parsedUrl.href}'`);
+        }
+        return ref;
+      }
+      
+      return super.resolve(ref, baseUri, options);
+      
+    } catch (e) {
+      if (process.env.DEBUG_SPECTRAL_RESOLVER) {
+        console.log(`[CUSTOM-RESOLVER] Deferring to default resolver for ref: '${ref}'`);
+      }
+      return super.resolve(ref, baseUri, options);
+    }
+  }
+}
+module.exports = new Resolver({
+  resolvers: {
+    http: new CustomResolver(),
+    https: new CustomResolver()
+  }
+});

--- a/test/specs/external-refs-spec.json
+++ b/test/specs/external-refs-spec.json
@@ -1,0 +1,155 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with External References",
+    "version": "1.0.0",
+    "description": "Test specification to verify external reference handling in API Insights"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "description": "Retrieve a list of users with manager references",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserList"
+                },
+                "examples": {
+                  "user-list": {
+                    "summary": "User list example with external manager reference",
+                    "value": {
+                      "users": [
+                        {
+                          "id": "user-123",
+                          "name": "John Doe",
+                          "email": "john.doe@example.com",
+                          "manager": {
+                            "$ref": "https://example.com/v2/Users/manager-456"
+                          }
+                        },
+                        {
+                          "id": "user-789",
+                          "name": "Jane Smith",
+                          "email": "jane.smith@example.com",
+                          "manager": {
+                            "$ref": "https://api.example.com/scim/v2/Users/manager-123"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userId}": {
+      "get": {
+        "summary": "Get user by ID",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique user identifier"
+          },
+          "name": {
+            "type": "string",
+            "description": "User's full name"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "User's email address"
+          },
+          "manager": {
+            "description": "Reference to user's manager",
+            "$ref": "https://example.com/v2/Users/manager-reference"
+          },
+          "department": {
+            "type": "string",
+            "description": "User's department"
+          }
+        },
+        "required": ["id", "name", "email"]
+      },
+      "UserList": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of users"
+          },
+          "next": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL for next page of results"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/specs/internal-refs-spec.json
+++ b/test/specs/internal-refs-spec.json
@@ -1,0 +1,175 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API with Internal References Only",
+    "version": "1.0.0",
+    "description": "Test specification with only internal references to verify normal operation"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "description": "Retrieve a list of users",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserList"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userId}": {
+      "get": {
+        "summary": "Get user by ID",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique user identifier"
+          },
+          "name": {
+            "type": "string",
+            "description": "User's full name"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "User's email address"
+          },
+          "profile": {
+            "$ref": "#/components/schemas/UserProfile"
+          },
+          "department": {
+            "type": "string",
+            "description": "User's department"
+          }
+        },
+        "required": ["id", "name", "email"]
+      },
+      "UserProfile": {
+        "type": "object",
+        "properties": {
+          "bio": {
+            "type": "string",
+            "description": "User's biography"
+          },
+          "avatar": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to user's avatar image"
+          },
+          "preferences": {
+            "$ref": "#/components/schemas/UserPreferences"
+          }
+        }
+      },
+      "UserPreferences": {
+        "type": "object",
+        "properties": {
+          "theme": {
+            "type": "string",
+            "enum": ["light", "dark"],
+            "default": "light"
+          },
+          "notifications": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "UserList": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of users"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationInfo"
+          }
+        }
+      },
+      "PaginationInfo": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "hasNext": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add custom resolver to prevent external $ref resolution
- Prevents network timeouts and 504 errors when processing OpenAPI specs
- Ignores HTTP/HTTPS external references, processes internal refs normally

