### PR TITLE
Fixes issue 57: Empty object schemas were incorrectly flagged as incomplete

### DIFF
--- a/functions/completedSchema.js
+++ b/functions/completedSchema.js
@@ -24,7 +24,7 @@
  * @param {Options} opts String requirements given by the linter ruleset
  */
 export default function (targetVal) {
-  if (typeof targetVal !== 'object') {
+  if (targetVal == null || typeof targetVal !== 'object') {
     return;
   }
 
@@ -38,6 +38,12 @@ export default function (targetVal) {
 
   // TODO: test
   if (targetVal.anyOf || targetVal.allOf || targetVal.oneOf || targetVal.not) {
+    return;
+  }
+
+  // An object with additionalProperties: false and no properties is a valid
+  // schema representing an intentionally empty object (e.g., {})
+  if (targetVal.additionalProperties === false) {
     return;
   }
 

--- a/functions/completedSchema.spec.js
+++ b/functions/completedSchema.spec.js
@@ -87,4 +87,88 @@ describe('completedSchema', () => {
       },
     ]);
   });
+
+  describe('additionalProperties: false (Issue #57)', () => {
+    test('should pass for empty object with additionalProperties: false', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+      };
+      expect(completedSchema(schema)).toBeUndefined();
+    });
+
+    test('should pass for empty object with additionalProperties: false and description', () => {
+      const schema = {
+        type: 'object',
+        description: 'Response for successful operation',
+        additionalProperties: false,
+      };
+      expect(completedSchema(schema)).toBeUndefined();
+    });
+
+    test('should pass for empty object with additionalProperties: false and example', () => {
+      const schema = {
+        type: 'object',
+        example: {},
+        additionalProperties: false,
+      };
+      expect(completedSchema(schema)).toBeUndefined();
+    });
+
+    test('should pass for v1AddOrUpdatePolicyConnectionsResponse pattern', () => {
+      const schema = {
+        type: 'object',
+        example: {},
+        description: 'Response for a successful association/disassociation of connections to a policy',
+        additionalProperties: false,
+      };
+      expect(completedSchema(schema)).toBeUndefined();
+    });
+
+    test('should fail for empty object without additionalProperties: false', () => {
+      const schema = {
+        type: 'object',
+      };
+      expect(completedSchema(schema)).toEqual([
+        { message: 'properties missing for object schema' },
+      ]);
+    });
+
+    test('should fail for empty object with additionalProperties: true', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: true,
+      };
+      expect(completedSchema(schema)).toEqual([
+        { message: 'properties missing for object schema' },
+      ]);
+    });
+
+    test('should fail for empty object with additionalProperties as schema', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+      };
+      expect(completedSchema(schema)).toEqual([
+        { message: 'properties missing for object schema' },
+      ]);
+    });
+
+    test('should pass for object with empty properties and additionalProperties: false', () => {
+      const schema = {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      };
+      expect(completedSchema(schema)).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should pass for non-object input', () => {
+      expect(completedSchema('string')).toBeUndefined();
+      expect(completedSchema(123)).toBeUndefined();
+      expect(completedSchema(null)).toBeUndefined();
+    });
+  });
 });

--- a/test/resources/general-schema-definition/positive.json
+++ b/test/resources/general-schema-definition/positive.json
@@ -20,6 +20,27 @@
     }
   ],
   "paths": {
+    "/ack": {
+      "get": {
+        "description": "Acknowledge.",
+        "operationId": "ack",
+        "tags": ["Sample"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Empty success response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/test": {
       "get": {
         "description": "Get some test data.",


### PR DESCRIPTION

**Issue:** 
Empty object schemas were incorrectly flagged as incomplete when they had `type: "object"`, no `properties`, and `additionalProperties: false`.

**Rule affected:** 
`general-schema-definition` (Contract Completeness / Doc Completeness)

**Fix:** 
Treat object schemas with `additionalProperties: false` as complete, since they explicitly define an empty object contract `{}`.

## Problem

Schemas like the following were reported with **"properties missing for object schema"**:

```json
{
  "type": "object",
  "example": {},
  "description": "Response for a successful association/disassociation of connections to a policy",
  "additionalProperties": false
}
```

This is a valid OpenAPI/JSON Schema: `additionalProperties: false` means no extra properties are allowed, so the only valid value is `{}`. Such schemas are commonly used for success acknowledgments, DELETE responses, and bulk-update responses.

## Solution
updates to `functions/completedSchema.js`

1. **Allow empty objects when `additionalProperties: false`**  
   Before returning the error, the function now returns early (no error) when `targetVal.additionalProperties === false`.

2. **Null-safe guard**  
   Added a check for `targetVal == null` so that `null` and other non-object inputs do not cause runtime errors and are treated as “skip” (return `undefined`).

## Tests

- Pass → Empty object with `additionalProperties: false` (with/without description, example, and v1AddOrUpdatePolicyConnectionsResponse-style); object with `properties: {}` and `additionalProperties: false`.
- Report error → Plain `type: "object"` with no `additionalProperties: false`; `additionalProperties: true`; `additionalProperties` as a schema object.
- Edge cases: Non-object inputs (string, number, `null`) pass (return `undefined`).
- `general-schema-definition` “should pass with provided schema” runs against `positive.json`, which now includes the `/ack` path with an empty-object schema. 


